### PR TITLE
fix: use absolute path for calendar API fetch

### DIFF
--- a/pages/calendar.js
+++ b/pages/calendar.js
@@ -5,7 +5,7 @@ import dayGridPlugin from '@fullcalendar/daygrid';
 function CalendarPage() {
   useEffect(() => {
     async function fetchEvents() {
-      const response = await fetch('./api/sheets');
+      const response = await fetch('/api/sheets');
       const data = await response.json();
 
       const eventArray = data.mappedData.map((event) => ({


### PR DESCRIPTION
## Summary
- fix event fetching path in calendar page to use absolute `/api/sheets`

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_689899b727a483258f0d23fcbef6bfde)